### PR TITLE
ci: fix Dependabot, pin actions to SHAs, and make Semgrep failures readable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,20 @@ updates:
         dependency-type: "development"
         patterns: ["*"]
 
+  # Semgrep CLI pin used by the semgrep workflow. Lives in its own directory
+  # because Dependabot's pip ecosystem reliably detects a file named exactly
+  # requirements.txt. Labelled "ci" so ci.yml routes it to quick-check, while
+  # the semgrep workflow's paths filter re-runs the scan on the new version.
+  - package-ecosystem: "pip"
+    directory: "/.github/semgrep"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    rebase-strategy: auto
+    labels: ["ci", "dependencies"]
+    commit-message:
+      prefix: "ci"
+
   # GitHub Actions - all updates, collapsed into a single pull request.
   # Refs are pinned to commit SHAs in the workflows; Dependabot reads the
   # trailing `# vX.Y.Z` comment on each `uses:` line to bump them.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,10 +14,11 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     rebase-strategy: auto
-    # Only "dependencies" here: Dependabot creates its own default labels but
-    # silently ignores custom ones that do not already exist in the repository,
-    # so nothing in CI may key off a label that is not created by hand first.
-    labels: ["dependencies"]
+    # "composer" exists purely for filtering and triage. Nothing in CI gates on
+    # it: Dependabot silently drops custom labels missing from the repository,
+    # so a job keyed off one would skip itself with no visible cause. ci.yml
+    # gates on the absence of "ci" instead, which fails towards more testing.
+    labels: ["dependencies", "composer"]
     commit-message:
       prefix: "deps"
     # Direct requirements only; transitive packages ride along with them.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,44 +1,47 @@
 version: 2
 updates:
-  # Production dependencies - MAJOR UPDATES ONLY
-  - package-ecosystem: "composer"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 3
-    rebase-strategy: auto
-    labels: ["dependencies", "production", "major-update"]
-    commit-message:
-      prefix: "deps(prod)"
-    # Only include production dependencies (require section)
-    allow:
-      - dependency-type: "direct:production"
-    # Ignore minor and patch updates for production dependencies
-    ignore:
-      - dependency-name: "guzzlehttp/guzzle"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-      - dependency-name: "league/oauth2-client"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-
-  # Dev dependencies - ALL UPDATES
+  # Composer - ONE entry only.
+  #
+  # Dependabot requires a unique (package-ecosystem, directory, target-branch)
+  # triple per update config. Production and development dependencies therefore
+  # cannot be split into two composer entries pointing at "/" - doing so makes
+  # Dependabot reject the whole file, which silently disables every ecosystem
+  # here, github-actions included. Use `groups` to separate them instead: each
+  # group still opens its own pull request.
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
     rebase-strategy: auto
-    labels: ["dependencies", "dev-only"]
+    # Only "dependencies" here: Dependabot creates its own default labels but
+    # silently ignores custom ones that do not already exist in the repository,
+    # so nothing in CI may key off a label that is not created by hand first.
+    labels: ["dependencies"]
     commit-message:
-      prefix: "deps(dev)"
-    # Only include dev dependencies (require-dev section)
+      prefix: "deps"
+    # Direct requirements only; transitive packages ride along with them.
     allow:
-      - dependency-type: "direct:development"
+      - dependency-type: "direct"
+    # Runtime HTTP and OAuth clients: major bumps only. Consumers of this
+    # library pin these themselves, so minor/patch churn adds no value here.
+    ignore:
+      - dependency-name: "guzzlehttp/guzzle"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "league/oauth2-client"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+    # Matched in order: a dependency lands in the first group it matches.
     groups:
+      production-dependencies:
+        dependency-type: "production"
+        patterns: ["*"]
       dev-dependencies:
-        patterns:
-          - "*"
+        dependency-type: "development"
+        patterns: ["*"]
 
-  # GitHub Actions - ALL UPDATES  
+  # GitHub Actions - all updates, collapsed into a single pull request.
+  # Refs are pinned to commit SHAs in the workflows; Dependabot reads the
+  # trailing `# vX.Y.Z` comment on each `uses:` line to bump them.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -49,5 +52,4 @@ updates:
       prefix: "ci"
     groups:
       github-actions:
-        patterns:
-          - "*"
+        patterns: ["*"]

--- a/.github/semgrep/requirements.txt
+++ b/.github/semgrep/requirements.txt
@@ -1,0 +1,10 @@
+# Semgrep CLI used by .github/workflows/semgrep.yml.
+#
+# Pinned so a new Semgrep release cannot change scan behaviour without a commit,
+# and kept in a requirements.txt so Dependabot's pip ecosystem can bump it - a
+# bare `pip install semgrep==...` in a workflow step is invisible to Dependabot.
+#
+# Note this pins the engine only. The --config=p/* rule packs are resolved from
+# the Semgrep registry at scan time, so new upstream rules can still surface
+# findings on a scheduled run against unchanged code.
+semgrep==1.171.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,11 @@ jobs:
     steps:
       # Download the repository source code to the runner
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       # Install PHP with required extensions and configure memory limit
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.3'
           extensions: openssl, mbstring  # Required extensions for the project
@@ -56,7 +56,7 @@ jobs:
 
       # Install project dependencies using cached composer packages for speed
       - name: Install dependencies (with cache)
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
         with:
           composer-options: --prefer-dist --no-progress --no-interaction
 
@@ -78,10 +78,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.3'
           extensions: openssl, mbstring
@@ -89,7 +89,7 @@ jobs:
           ini-values: memory_limit=-1
 
       - name: Install dependencies (with cache)
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
         with:
           composer-options: --prefer-dist --no-progress --no-interaction
 
@@ -119,12 +119,12 @@ jobs:
     steps:
       # Download the repository source code to the runner
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       # Install PHP with conditional coverage (Xdebug only on PHP 8.3)
       - name: Setup PHP (no coverage)
         if: ${{ matrix.php-version != '8.3' }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-version }}
           extensions: openssl, mbstring  # Required extensions for the project
@@ -133,7 +133,7 @@ jobs:
 
       - name: Setup PHP (with Xdebug)
         if: ${{ matrix.php-version == '8.3' }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-version }}
           extensions: openssl, mbstring  # Required extensions for the project
@@ -142,7 +142,7 @@ jobs:
 
       # Install project dependencies using cached composer packages for speed
       - name: Install dependencies (with cache)
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
         with:
           composer-options: --prefer-dist --no-progress --no-interaction
 
@@ -159,7 +159,7 @@ jobs:
       # Upload test results and coverage data as artifacts (PHP 8.3 only)
       - name: Upload coverage artifacts
         if: ${{ always() && matrix.php-version == '8.3' }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: coverage-php-${{ matrix.php-version }}
           path: |
@@ -178,11 +178,11 @@ jobs:
     steps:
       # Download the repository source code to the runner
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       # Install PHP without coverage since we only need basic functionality testing
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.3'
           extensions: openssl, mbstring  # Required extensions for the project
@@ -209,10 +209,10 @@ jobs:
     needs: lint
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.3'
           extensions: openssl, mbstring
@@ -220,7 +220,7 @@ jobs:
           ini-values: memory_limit=-1
 
       - name: Install dependencies (with cache)
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
         with:
           composer-options: --prefer-dist --no-progress --no-interaction
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       # Download the repository source code to the runner
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Install PHP with required extensions and configure memory limit
       - name: Setup PHP
@@ -56,7 +56,7 @@ jobs:
 
       # Install project dependencies using cached composer packages for speed
       - name: Install dependencies (with cache)
-        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           composer-options: --prefer-dist --no-progress --no-interaction
 
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
@@ -89,7 +89,7 @@ jobs:
           ini-values: memory_limit=-1
 
       - name: Install dependencies (with cache)
-        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           composer-options: --prefer-dist --no-progress --no-interaction
 
@@ -119,7 +119,7 @@ jobs:
     steps:
       # Download the repository source code to the runner
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Install PHP with conditional coverage (Xdebug only on PHP 8.3)
       - name: Setup PHP (no coverage)
@@ -142,7 +142,7 @@ jobs:
 
       # Install project dependencies using cached composer packages for speed
       - name: Install dependencies (with cache)
-        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           composer-options: --prefer-dist --no-progress --no-interaction
 
@@ -159,7 +159,7 @@ jobs:
       # Upload test results and coverage data as artifacts (PHP 8.3 only)
       - name: Upload coverage artifacts
         if: ${{ always() && matrix.php-version == '8.3' }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-php-${{ matrix.php-version }}
           path: |
@@ -178,7 +178,7 @@ jobs:
     steps:
       # Download the repository source code to the runner
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Install PHP without coverage since we only need basic functionality testing
       - name: Setup PHP
@@ -209,7 +209,7 @@ jobs:
     needs: lint
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
@@ -220,7 +220,7 @@ jobs:
           ini-values: memory_limit=-1
 
       - name: Install dependencies (with cache)
-        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           composer-options: --prefer-dist --no-progress --no-interaction
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,14 +100,13 @@ jobs:
   tests:
     name: Tests (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-latest
-    # Run full tests on:
-    # 1. Non-Dependabot PRs
-    # 2. Dependabot PRs with "major-update" or "production" labels (production deps)
-    # Skip full tests on dev-only and ci updates to save resources
+    # Run full tests on everything except Dependabot's action-only updates,
+    # which carry the "ci" label and are covered by quick-check instead.
+    # Keyed on the absence of "ci" rather than the presence of a Composer label,
+    # because Dependabot drops custom labels that do not exist in the repo.
     if: |
-      github.actor != 'dependabot[bot]' || 
-      contains(github.event.pull_request.labels.*.name, 'major-update') ||
-      contains(github.event.pull_request.labels.*.name, 'production')
+      github.actor != 'dependabot[bot]' ||
+      !contains(github.event.pull_request.labels.*.name, 'ci')
     needs: [lint, analyse]
     strategy:
       # Continue running all matrix jobs even if one fails to get full coverage of results.
@@ -170,10 +169,10 @@ jobs:
   lowest-deps:
     name: Lowest Deps (PHP 8.3)
     runs-on: ubuntu-latest
-    # Only run on non-Dependabot or production dependency updates
+    # Only run on non-Dependabot PRs or Dependabot's Composer updates
     if: |
-      github.actor != 'dependabot[bot]' || 
-      contains(github.event.pull_request.labels.*.name, 'production')
+      github.actor != 'dependabot[bot]' ||
+      !contains(github.event.pull_request.labels.*.name, 'ci')
     needs: lint
     steps:
       # Download the repository source code to the runner
@@ -197,15 +196,14 @@ jobs:
       - name: Run PHPUnit (no coverage)
         run: composer test
 
-  # Lightweight check for dev-only and CI updates
+  # Lightweight check for GitHub Actions updates
   quick-check:
-    name: Quick Check (Dev/CI Updates)
+    name: Quick Check (CI Updates)
     runs-on: ubuntu-latest
-    # Only run on Dependabot PRs that are dev-only or ci updates
+    # Only run on Dependabot PRs that bump actions
     if: |
-      github.actor == 'dependabot[bot]' && 
-      (contains(github.event.pull_request.labels.*.name, 'dev-only') || 
-       contains(github.event.pull_request.labels.*.name, 'ci'))
+      github.actor == 'dependabot[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'ci')
     needs: lint
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -14,7 +14,7 @@ jobs:
       RELEASE_TAG: v${{ inputs.version }}
     steps:
       - name: Checkout repository with SSH
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
           fetch-depth: 0

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -14,7 +14,7 @@ jobs:
       RELEASE_TAG: v${{ inputs.version }}
     steps:
       - name: Checkout repository with SSH
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
           fetch-depth: 0
@@ -36,7 +36,7 @@ jobs:
           fi
 
       - name: Generate release notes
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           config: cliff.release.toml
           args: --unreleased --tag "${{ env.RELEASE_TAG }}" -vv -o new_notes.md

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -8,6 +8,8 @@ on:
       - "composer.*"
       - ".semgrep*"
       - ".github/workflows/**/*.yml"
+      # So a Dependabot bump of the pinned Semgrep version is validated by a scan.
+      - ".github/semgrep/requirements.txt"
   pull_request:
     branches: [ main ]
     paths:
@@ -15,6 +17,8 @@ on:
       - "composer.*"
       - ".semgrep*"
       - ".github/workflows/**/*.yml"
+      # So a Dependabot bump of the pinned Semgrep version is validated by a scan.
+      - ".github/semgrep/requirements.txt"
   schedule:
     - cron: '0 3 * * 1'   # Every Monday at 03:00 UTC
   workflow_dispatch:       # Manual trigger from the Actions tab
@@ -36,11 +40,10 @@ jobs:
         with:
           python-version: '3.x'
 
-      # Pinned so a new Semgrep release cannot silently change scan behaviour.
-      # Note: the p/* rule packs below are still resolved from the registry at run time,
-      # so newly published upstream rules can introduce findings without a repo change.
+      # Version is pinned in the requirements file so Dependabot can bump it.
+      # That pins the engine only - see the note in that file about rule packs.
       - name: Install Semgrep
-        run: pip install semgrep==1.171.0
+        run: pip install -r .github/semgrep/requirements.txt
 
       # --text keeps the human-readable findings in the job log (the default --sarif
       # output swallows them), while --sarif-output/--text-output write the files the

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.x'
 
@@ -78,7 +78,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         if: always()
         with:
           sarif_file: semgrep.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -36,9 +36,15 @@ jobs:
         with:
           python-version: '3.x'
 
+      # Pinned so a new Semgrep release cannot silently change scan behaviour.
+      # Note: the p/* rule packs below are still resolved from the registry at run time,
+      # so newly published upstream rules can introduce findings without a repo change.
       - name: Install Semgrep
-        run: pip install semgrep
+        run: pip install semgrep==1.171.0
 
+      # --text keeps the human-readable findings in the job log (the default --sarif
+      # output swallows them), while --sarif-output/--text-output write the files the
+      # later steps consume. --error still fails the job on any blocking finding.
       - name: Run Semgrep and generate SARIF
         run: |
           semgrep scan \
@@ -47,10 +53,29 @@ jobs:
             --config=p/github-actions \
             --config=p/security-audit \
             --exclude-rule=php.lang.security.injection.tainted-sql-string.tainted-sql-string \
-            --sarif --output=semgrep.sarif \
+            --text \
+            --text-output=semgrep.txt \
+            --sarif-output=semgrep.sarif \
             --error \
             --timeout 600 \
             .
+
+      # Mirror the findings onto the run summary page so a failure can be triaged
+      # without opening the job log or cross-referencing the Security tab.
+      - name: Publish findings to run summary
+        if: always()
+        run: |
+          {
+            echo '## Semgrep'
+            echo
+            if [ -s semgrep.txt ]; then
+              echo '````'
+              head -c 900000 semgrep.txt
+              echo '````'
+            else
+              echo '_Semgrep produced no output._'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload SARIF to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
Fixes the failing scheduled Semgrep scan ([run 30242652375](https://github.com/BrightLeaf-Digital/asana-client/actions/runs/30242652375)) and, along the way, the reason Dependabot has been silent since December.

## What was wrong

**Semgrep, 21 blocking findings.** All 21 were one rule — `yaml.github-actions.security.github-actions-mutable-action-tag` (CWE-1357, CWE-353) — one per `uses:` line. Zero PHP findings; nothing was wrong with the library code. Nothing in the repo changed either: the 2026-07-20 run was 37 rules / 0 findings, 2026-07-27 was 43 rules / 21 findings on the same commit. The `p/github-actions` registry pack gained rules.

**Dependabot was rejecting `dependabot.yml` outright:**

> Update configs must have a unique combination of `package-ecosystem`, `directory`, and `target-branch`. Ecosystem `composer` has overlapping directories.

Two `composer` entries both targeted `directory: "/"` (production monthly, dev weekly). That triple must be unique, and a parse failure takes down **every** ecosystem in the file — so `github-actions` was collateral damage. Last version-update PR was 2025-12-22, despite updates being available since 2026-02-26.

## Commits

| | |
|---|---|
| `1e401f4` | Semgrep reporting: findings in the job log + run summary |
| `a8f2c8a` | Pin all 21 action refs to commit SHAs (no version change) |
| `b65d716` | Bump the four actions with a newer major |
| `7667056` | Fix the invalid Dependabot config |
| `686f907` | Move the Semgrep pin into a requirements file |
| `c4eef6f` | Label Composer PRs for triage |

### Semgrep reporting

`--sarif --output=` made SARIF the primary output, so the job log got only `Findings: 21` and the detail went to a file. Now `--text` is primary with `--text-output`/`--sarif-output` writing files, and a new step mirrors the findings into `$GITHUB_STEP_SUMMARY`. A failure is readable from the run page.

### Action pinning

Pinning is split from bumping so the mechanical change is verifiable on its own. Each ref carries a `# vX.Y.Z` comment, which is what Dependabot reads to bump SHA pins.

```
actions/checkout         v6.1.0 -> v7.0.1
actions/setup-python     v6.3.0 -> v7.0.0
actions/upload-artifact  v6.0.0 -> v7.0.1
ramsey/composer-install  3.2.1  -> 4.0.0
```

Breaking changes reviewed; none apply. checkout/setup-python/upload-artifact moved to ESM; setup-python dropped the unused `pip-install` input; upload-artifact added an opt-in `archive` input; composer-install 4.0.0 requires Actions Runner >= 2.327.1, which only affects self-hosted runners (every job here is `ubuntu-latest`).

`setup-php` (2.37.2), `git-cliff-action` (v4.8.0) and `codeql-action` (v4.37.3) were already latest within their major — pinned, not bumped.

Note `ramsey/composer-install@v3` was a **branch** (`refs/heads/v3`), not a tag; that repo has no `main` and uses one branch per major. Upstream's own README now recommends the same SHA-plus-comment convention used here.

### Dependabot

One `composer` entry, with production and development split via `groups` + `dependency-type` (still one PR per group). `allow: direct` preserves the previous `direct:production` / `direct:development` intent.

The old `production` / `dev-only` / `major-update` labels are gone, so job gating moved to the **absence** of the existing `ci` label. Dependabot silently drops custom labels that don't exist in the repo, so gating on a new label would have skipped tests with no visible cause. Keying on `ci` fails towards more testing:

| PR | tests | lowest-deps | quick-check |
|---|---|---|---|
| Human | yes | yes | — |
| Dependabot Composer | yes | yes | — |
| Dependabot actions / pip (`ci`) | — | — | yes |

Tradeoff: dev-dependency bumps now run the full suite including `lowest-deps` — marginally more CI, strictly safer. The `composer` label exists for filtering only; no job branches on it.

### Semgrep pin

`pip install semgrep==1.171.0` in a `run:` step is not a manifest, so Dependabot couldn't see it and the pin would rot. It now lives in `.github/semgrep/requirements.txt` with a `pip` ecosystem entry, and that path was added to the workflow's `paths:` filter so a version bump is validated by an actual scan instead of merged untested.

This pins the **engine only**. The `--config=p/*` packs are resolved from the registry at scan time, so upstream rule additions can still surface findings on a scheduled run — which is why the reporting fix matters.

## Verification

- Semgrep 1.171.0, same four packs, against this branch: **0 findings, exit 0** (was 21).
- `--text` + `--text-output` + `--sarif-output` confirmed to produce all three outputs simultaneously with exit code preserved.
- `pip install --dry-run` on a clean `python:3-slim` resolves `semgrep-1.171.0`.
- All four YAML files parse; the Dependabot uniqueness triple is unique; every label referenced by the config exists in the repo.

Not verifiable locally: the Dependabot config and pip manifest detection only prove themselves once this is on `main`. After merge, use **Check for updates** on `/network/updates` rather than waiting for the weekly tick, and confirm the parse-error banner is gone. Expect a production-group PR (guzzle 7 -> 8 is available — a major on a public library's runtime dependency, worth a real review) and a dev-group PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)