### PR TITLE
ci: drop path filters from workflows whose checks are required

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,8 +42,8 @@ updates:
 
   # Semgrep CLI pin used by the semgrep workflow. Lives in its own directory
   # because Dependabot's pip ecosystem reliably detects a file named exactly
-  # requirements.txt. Labelled "ci" so ci.yml routes it to quick-check, while
-  # the semgrep workflow's paths filter re-runs the scan on the new version.
+  # requirements.txt. Labelled "ci" so ci.yml routes it to quick-check; the
+  # semgrep workflow has no path filters, so it validates the bump on every PR.
   - package-ecosystem: "pip"
     directory: "/.github/semgrep"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,23 +10,23 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Deliberately NO paths / paths-ignore filters here.
+#
+# Lint, Analyse and Tests are required status checks on main. When a workflow is
+# skipped by a path filter its checks are never reported, so they sit at
+# "Expected - waiting for status to be reported" and the pull request can never
+# be merged. A docs-only change would deadlock. (A job skipped by an `if:`
+# condition is different - that reports Success and does not block.)
+#
+# The saving was roughly a minute of runner time on docs-only changes, which is
+# not worth an unmergeable pull request. If it ever becomes worth it, gate the
+# individual jobs with `if:` on a changed-files step rather than filtering the
+# workflow trigger.
 on:
-  # Trigger on pushes to main, but ignore docs/markdown-only changes to save CI minutes.
   push:
     branches: [ main ]
-    paths-ignore:
-      - 'README.md'
-      - 'readme.md'
-      - 'CHANGELOG.md'
-      - 'docs/**'
-  # Trigger on PRs targeting the main with the same path ignores.
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - 'README.md'
-      - 'readme.md'
-      - 'CHANGELOG.md'
-      - 'docs/**'
   # Allow manual runs from the Actions UI.
   workflow_dispatch:
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,24 +1,15 @@
 name: semgrep (php)
 
+# Deliberately NO paths filters here. "semgrep" is a required status check on
+# main, and a workflow skipped by a path filter never reports its check, leaving
+# the pull request stuck at "Expected - waiting for status to be reported".
+# The previous filter list also had to be kept in sync by hand with every new
+# scanned path, which is its own failure mode. A scan is ~40s; just always run.
 on:
   push:
     branches: [ main ]
-    paths:
-      - "**/*.php"
-      - "composer.*"
-      - ".semgrep*"
-      - ".github/workflows/**/*.yml"
-      # So a Dependabot bump of the pinned Semgrep version is validated by a scan.
-      - ".github/semgrep/requirements.txt"
   pull_request:
     branches: [ main ]
-    paths:
-      - "**/*.php"
-      - "composer.*"
-      - ".semgrep*"
-      - ".github/workflows/**/*.yml"
-      # So a Dependabot bump of the pinned Semgrep version is validated by a scan.
-      - ".github/semgrep/requirements.txt"
   schedule:
     - cron: '0 3 * * 1'   # Every Monday at 03:00 UTC
   workflow_dispatch:       # Manual trigger from the Actions tab


### PR DESCRIPTION
Follow-up to #17. Removes a latent deadlock in the required status checks.

## The problem

`Lint (PHP 8.3)`, `Analyse (PHP 8.3)`, `Tests (PHP 8.3)` and `semgrep` are required status checks on `main`. A workflow **skipped by a path filter never reports its checks** — they sit at *"Expected — waiting for status to be reported"* and the PR can never be merged.

- `ci.yml` had `paths-ignore` for `README.md`, `readme.md`, `CHANGELOG.md`, `docs/**` → any docs-only PR would deadlock.
- `semgrep.yml` ran only on an allowlist (`**/*.php`, `composer.*`, `.semgrep*`, workflow yml, and the requirements file) → most PRs that touch nothing on that list would deadlock on `semgrep`.

This is specific to **workflow-level** skips. A job skipped by an `if:` condition reports **Success** and does not block — which is why the Dependabot label gating in `ci.yml` is fine and why `Quick Check` skipping on #17 was harmless.

Never observed because the ruleset was created 2026-02-25 and every PR since was merged with an admin bypass.

## The fix

Drop the filters; both workflows always run on push to `main` and on PRs. Costs roughly a minute of runner time on docs-only changes, which beats an unmergeable PR. The `semgrep.yml` allowlist also had to be hand-maintained against every new scanned path — a second failure mode of the same kind.

If the runner time ever matters, the correct shape is to gate individual **jobs** with `if:` on a changed-files step, since job-level skips report Success.

Also refreshes the now-stale comment in `dependabot.yml` that referred to the semgrep paths filter.

## Related settings change

`Tests (PHP 7.4)` has been removed from the `main-protection-with-automation-bypass` ruleset. It could never report — the `ci.yml` matrix has been `['8.3']` since 2026-04-21, while the ruleset was authored on 2026-02-25 when the matrix still included 7.4. Required checks are now:

```
semgrep · Lint (PHP 8.3) · Analyse (PHP 8.3) · Tests (PHP 8.3)
```

Everything else in the ruleset is unchanged (deletion, non-fast-forward, linear history, 1 approving review, strict policy, OrganizationAdmin/DeployKey bypasses).

Note `Lowest Deps (PHP 8.3)` is still *not* required — it runs and passes, but nothing enforces it. Worth adding if you want it enforced.

## Verification

This PR is itself the test: it touches only `.github/**`, so under the old `semgrep.yml` allowlist it would have matched `.github/workflows/**/*.yml` and run — but a docs-only PR would not have. All four required checks should now report on every PR regardless of what changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)